### PR TITLE
fix: Correction of setting credentials in environment

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -218,13 +218,14 @@ runs:
         echo "aws_secret_access_key=$awsSecretAccessKey" >> "$GITHUB_OUTPUT"
         echo "aws_session_token=$awsSessionToken" >> "$GITHUB_OUTPUT"
 
-    - name: "Configure AWS Credentials"
+    - name: "Set Credentials in Environment"
       if: ${{ inputs.set-in-environment == 'true' }}
       shell: bash
       run: |
-        aws configure set aws_access_key_id ${{ steps.authenticate.outputs.aws_access_key_id }}
-        aws configure set aws_secret_access_key ${{ steps.authenticate.outputs.aws_secret_access_key }}
-        aws configure set aws_session_token ${{ steps.authenticate.outputs.aws_session_token }}
+        echo "AWS_ACCESS_KEY_ID=${{ steps.authenticate.outputs.aws_access_key_id }}" >> "$GITHUB_ENV"
+        echo "AWS_SECRET_ACCESS_KEY=${{ steps.authenticate.outputs.aws_secret_access_key }}" >> "$GITHUB_ENV"
+        echo "AWS_SESSION_TOKEN=${{ steps.authenticate.outputs.aws_session_token }}" >> "$GITHUB_ENV"
+        echo "AWS_REGION=${{ steps.aws_region.outputs.value }}" >> "$GITHUB_ENV"
 
     - name: "Set as Profile"
       if: ${{ inputs.set-as-profile != '' }}


### PR DESCRIPTION
When I released this action I managed to include an older version that is not settings the credentials in the environment. This now works the same as it does for [catnekaise/cognito-idpool-basic-auth](https://github.com/catnekaise/cognito-idpool-basic-auth).