### PR TITLE
Support creating a `repository_name` claim when chaining

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,37 @@ If performing a role-chain, those credentials are used as output.
 | aws_region            |
 
 ## Passing Claims (Session Tags)
+
+It's possible to pass one or more claims from the initial role session to the next session when role chaining. This is done by specifying one or more GitHub Actions claims in `chain-pass-claims`.
+
 > [!WARNING]
-> Make sure the role being assumed allows `sts:TagSession` and that any claims being passed is validated by the trust policy. Not validating the claims could allow a workflow to alter values of the claims.
+> Make sure the role being assumed allows `sts:TagSession` and that any claims being passed are validated by an `sts:AssumeRole` permissions policy. **If this is not done, it might be possible for an attacker to escalate privileges** if they manually make the same calls this action makes, but substitute their own values for the tags when chaining roles.
+
+For example, if `chain-pass-claims` is `job_workflow_ref,repository`, then the following condition could be used in the IAM policy on the initial role:
+
+```json
+{
+  "Sid": "AllowAssumptionIfTagsMatch",
+  "Effect": "Allow",
+  "Action": "sts:AssumeRole",
+  "Resource": "arn:aws:iam::*:role/pattern-matching-the-roles-to-allow-*",
+  "Condition": {
+    "Null": {
+      "aws:TagKeys": "false"
+    },
+    "ForAllValues:StringEquals": {
+      "aws:TagKeys": ["job_workflow_ref", "repository"]
+    },
+    "StringEquals": {
+      "sts:RoleSessionName": "GitHubActions",
+      "aws:PrincipalTag/Repository": "${aws:RequestTag/repository}",
+      "aws:PrincipalTag/job_workflow_ref": "${aws:RequestTag/job_workflow_ref}"
+    }
+  }
+}
+```
+
+This verifies that all the expected tags are set, and that the values match the ones we got from the GitHub token. The principal at this point is the initial role session, with `PrincipalTag` tags set by Cognito from the GitHub Actions claims. The `aws:RequestTag` tags are the tags passed by the caller of `AssumeRole` - i.e. this action or an attacker.
 
 > [!IMPORTANT]
 > The claims job_workflow_ref and environment is not available via an environment variable. Because of this, this action will parse the GitHub Actions access token already available and used in this action to find the value of these claims.
@@ -119,11 +148,15 @@ If performing a role-chain, those credentials are used as output.
 > 
 > Find step with id "missing_claims" in action.yml to view details.
 
-It's possible to pass one or more claims from the initial role session to the next session when role chaining. This is done by specifying one or more GitHub Actions claims in `chain-pass-claims`.
-
 The following claims can be passed by this action: `actor`, `actor_id`, `base_ref`, `event_name`, `head_ref`, `job_workflow_ref`, `ref`, `ref_type`, `repository`, `repository_id`, `repository_name`, `repository_owner`, `repository_owner_id`, `run_attempt`, `run_id`, `run_number`, `runner_environment`, `sha`, and `environment`.
 
-`repository_name` is a special case. GitHub doesn't provide this as a claim, but it's derived from `repository` claim (which is of the form `repository_owner/repository_name`) as it is often used in IAM policies.
+`repository_name` is a special case. GitHub doesn't provide this as a claim, but it's derived from `repository` claim (which is of the form `repository_owner/repository_name`) as it is often used in IAM policies. As above, you **must** validate this claim. You can use a condition like:
+
+```json
+"aws:PrincipalTag/Repository": "${aws:PrincipalTag/repository_owner}/${aws:RequestTag/repository_name}"
+```
+
+to do this. Note that this requires you to also map `repository_owner` in your Cognito Identity Pool.
 
 | Input                        | Comment                                                                |
 |------------------------------|------------------------------------------------------------------------|

--- a/README.md
+++ b/README.md
@@ -121,7 +121,9 @@ If performing a role-chain, those credentials are used as output.
 
 It's possible to pass one or more claims from the initial role session to the next session when role chaining. This is done by specifying one or more GitHub Actions claims in `chain-pass-claims`.
 
-The following claims can be passed by this action: `actor`, `actor_id`, `base_ref`, `event_name`, `head_ref`, `job_workflow_ref`, `ref`, `ref_type`, `repository`, `repository_id`, `repository_owner`, `repository_owner_id`, `run_attempt`, `run_id`, `run_number`, `runner_environment`, `sha`, and `environment`.
+The following claims can be passed by this action: `actor`, `actor_id`, `base_ref`, `event_name`, `head_ref`, `job_workflow_ref`, `ref`, `ref_type`, `repository`, `repository_id`, `repository_name`, `repository_owner`, `repository_owner_id`, `run_attempt`, `run_id`, `run_number`, `runner_environment`, `sha`, and `environment`.
+
+`repository_name` is a special case. GitHub doesn't provide this as a claim, but it's derived from `repository` claim (which is of the form `repository_owner/repository_name`) as it is often used in IAM policies.
 
 | Input                        | Comment                                                                |
 |------------------------------|------------------------------------------------------------------------|

--- a/action.yml
+++ b/action.yml
@@ -49,7 +49,7 @@ inputs:
   chain-pass-claims:
     default: ""
     required: false
-    description: "Pass claims"
+    description: "Claims from ID token to pass to the role when performing role chaining. Can also include `repository_name`, which will be calculated."
   chain-set-as-profile:
     default: ""
     required: false
@@ -472,7 +472,7 @@ runs:
         VALUE_ENVIRONMENT: "${{ steps.missing_claims.outputs.environment }}"
       shell: bash
       run: |
-        declare -a supports=("actor" "actor_id" "base_ref" "event_name" "head_ref" "job_workflow_ref" "ref" "ref_type" "repository" "repository_id" "repository_owner" "repository_owner_id" "run_attempt" "run_id" "run_number" "runner_environment" "sha" "environment")
+        declare -a supports=("actor" "actor_id" "base_ref" "event_name" "head_ref" "job_workflow_ref" "ref" "ref_type" "repository" "repository_id" "repository_name" "repository_owner" "repository_owner_id" "run_attempt" "run_id" "run_number" "runner_environment" "sha" "environment")
 
         IFS=', ' read -ra claims <<< "$PASS_CLAIMS"
 
@@ -498,6 +498,11 @@ runs:
             value=$RUNNER_ENVIRONMENT
           elif [ "$claim" == "job_workflow_ref" ]; then
             value="$VALUE_JOB_WORKFLOW_REF"
+          elif [ "$claim" == "repository_name" ]; then
+            # The repository name is not available as an environment variable,
+            # so it needs to be parsed from the owner/repo which is in
+            # ${GITHUB_REPOSITORY}
+            value="${GITHUB_REPOSITORY##*/}"
           else
               value=$(printenv "GITHUB_${claim^^}")
           fi

--- a/action.yml
+++ b/action.yml
@@ -474,16 +474,27 @@ runs:
       run: |
         declare -a supports=("actor" "actor_id" "base_ref" "event_name" "head_ref" "job_workflow_ref" "ref" "ref_type" "repository" "repository_id" "repository_name" "repository_owner" "repository_owner_id" "run_attempt" "run_id" "run_number" "runner_environment" "sha" "environment")
 
+        # Make sure PASS_CLAIMS ends with a comma, so we read all the claims
+        PASS_CLAIMS="${PASS_CLAIMS%,},"
+
         # Read user-supplied claims into an associative array so we can test if
         # a claim is requested
         declare -A claims
-        while IFS=', ' read -r claim; do
-          claims[$claim]=1
-        done <<< "$PASS_CLAIMS"
+        while IFS=' ' read -r -d',' pass_claim; do
+          if [ -z "${pass_claim}" ]; then
+            continue
+          fi
+
+          # Split the claim at '=' and take the first part. This could be e.g.
+          # `repository=repo`, and we want to know if the user has mapped
+          # `repository`.
+          claim_name="${pass_claim%%=*}"
+          claims[${claim_name}]="${pass_claim}"
+        done <<< "${PASS_CLAIMS}"
 
         tags=()
 
-        for c in "${!claims[@]}"; do
+        for c in "${claims[@]}"; do
 
           IFS='=' read -ra parts <<< "$c"
           claim=${parts[0],,}

--- a/action.yml
+++ b/action.yml
@@ -515,11 +515,11 @@ runs:
           elif [ "$claim" == "job_workflow_ref" ]; then
             value="$VALUE_JOB_WORKFLOW_REF"
           elif [ "$claim" == "repository_name" ]; then
-            # Ensure that both `repository` and `repository_owner` are being
+            # Ensure that one of `repository` or `repository_owner` is being
             # passed; they are required to validate repository name with a
             # condition.
-            if ! [[ -v claims[repository] && -v claims[repository_owner] ]]; then
-              echo "::warning::repository_name is being passed, but repository and repository_owner are not. You need to pass both in order to validate repository name in your IAM policy. Read more: https://github.com/catnekaise/cognito-idpool-auth#passing-repository-name"
+            if ! [[ -v claims[repository] || -v claims[repository_owner] ]]; then
+              echo "::warning::repository_name is being passed, but neither repository nor repository_owner are. At least one of these should be passed, so you can match the GitHub organization in your IAM policies. Read more: https://github.com/catnekaise/cognito-idpool-auth#passing-repository-name"
             fi
 
             # The repository name is not available as an environment variable,

--- a/action.yml
+++ b/action.yml
@@ -474,12 +474,17 @@ runs:
       run: |
         declare -a supports=("actor" "actor_id" "base_ref" "event_name" "head_ref" "job_workflow_ref" "ref" "ref_type" "repository" "repository_id" "repository_name" "repository_owner" "repository_owner_id" "run_attempt" "run_id" "run_number" "runner_environment" "sha" "environment")
 
-        IFS=', ' read -ra claims <<< "$PASS_CLAIMS"
+        # Read user-supplied claims into an associative array so we can test if
+        # a claim is requested
+        declare -A claims
+        while IFS=', ' read -r claim; do
+          claims[$claim]=1
+        done <<< "$PASS_CLAIMS"
 
         tags=()
-        
-        for c in "${claims[@]}"; do
-        
+
+        for c in "${!claims[@]}"; do
+
           IFS='=' read -ra parts <<< "$c"
           claim=${parts[0],,}
           tagName=${parts[1]}
@@ -499,6 +504,13 @@ runs:
           elif [ "$claim" == "job_workflow_ref" ]; then
             value="$VALUE_JOB_WORKFLOW_REF"
           elif [ "$claim" == "repository_name" ]; then
+            # Ensure that both `repository` and `repository_owner` are being
+            # passed; they are required to validate repository name with a
+            # condition.
+            if ! [[ -v claims[repository] && -v claims[repository_owner] ]]; then
+              echo "::warning::repository_name is being passed, but repository and repository_owner are not. You need to pass both in order to validate repository name in your IAM policy. Read more: https://github.com/catnekaise/cognito-idpool-auth#passing-repository-name"
+            fi
+
             # The repository name is not available as an environment variable,
             # so it needs to be parsed from the owner/repo which is in
             # ${GITHUB_REPOSITORY}


### PR DESCRIPTION
GitHub doesn't provide a claim in its token, or an environment variable/context value containing just the repository's name. It does give the owner in `repository_owner` though.

Having this available as a tag will be very useful when constructing policies. For example, you could create a policy that allows repos to push to s3 buckets named like

```
mycompany-${aws:RequestTag/repository_owner}-${aws:RequestTag/repository_name}
```

WDYT?

As an alternative, I could imagine an input to allow any custom tags to be sent, but I'm not sure we want to go that far.

(thanks for this action by the way, it's super helpful!)