### PR TITLE
Added ability to customize Identity Provider Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,21 +61,23 @@ jobs:
 ## Standard Input Parameters
 
 - `cognito-identity-pool-id` and `auth-flow` are required.
+- `cognito-identity-provider-name` can be used if [issuer OIDC claim is customized](https://docs.github.com/en/enterprise-cloud@latest/actions/security-for-github-actions/security-hardening-your-deployments/about-security-hardening-with-openid-connect#customizing-the-issuer-value-for-an-enterprise).
 - `aws-account-id` and `aws-region` are required, but values can optionally be derived from environment variables, if this behaviour is wanted.
 - If providing `role-arn` and `auth-flow` is `enhanced`, then `aws-account-id` can be extracted from the ARN.
 - Input to action via parameters will supersede environment variables for `aws-account-id` and `aws-region`.
   - **Env Var 1** supersedes **Env Var 2**.
 
-| Input Parameter Name     | Default                        | Example                             | Env Var 1                 | Env Var 2          |
-|--------------------------|--------------------------------|-------------------------------------|---------------------------|--------------------|
-| cognito-identity-pool-id | -                              | eu-west-1:11111111-example          | -                         | -                  |
-| auth-flow                | -                              | basic or enhanced                   | -                         | -                  |
-| aws-account-id           | -                              | 1111111111111                       | CK_COGNITO_AWS_ACCOUNT_ID | AWS_ACCOUNT_ID     |
-| aws-region               | -                              | eu-west-1                           | AWS_REGION                | AWS_DEFAULT_REGION |
-| audience                 | cognito-identity.amazonaws.com | cognito-identity.amazonaws.com      | -                         | -                  |
-| role-arn                 | -                              | arn:aws:iam::111111111111:role/role | -                         | -                  |
-| set-as-profile           | -                              | cache                               | -                         | -                  |
-| set-in-environment       | -                              | true                                | -                         | -                  |
+| Input Parameter Name           | Default                             | Example                             | Env Var 1                 | Env Var 2          |
+|--------------------------------|-------------------------------------|-------------------------------------|---------------------------|--------------------|
+| cognito-identity-pool-id       | -                                   | eu-west-1:11111111-example          | -                         | -                  |
+| cognito-identity-provider-name | token.actions.githubusercontent.com | token.actions.githubusercontent.com | -                         | -                  |
+| auth-flow                      | -                                   | basic or enhanced                   | -                         | -                  |
+| aws-account-id                 | -                                   | 1111111111111                       | CK_COGNITO_AWS_ACCOUNT_ID | AWS_ACCOUNT_ID     |
+| aws-region                     | -                                   | eu-west-1                           | AWS_REGION                | AWS_DEFAULT_REGION |
+| audience                       | cognito-identity.amazonaws.com      | cognito-identity.amazonaws.com      | -                         | -                  |
+| role-arn                       | -                                   | arn:aws:iam::111111111111:role/role | -                         | -                  |
+| set-as-profile                 | -                                   | cache                               | -                         | -                  |
+| set-in-environment             | -                                   | true                                | -                         | -                  |
 
 
 ## Basic AuthFlow Parameters

--- a/action.yml
+++ b/action.yml
@@ -94,6 +94,7 @@ runs:
       env:
         AUTH_FLOW: "${{ inputs.auth-flow }}"
         COGNITO_POOL_ID: "${{ inputs.cognito-identity-pool-id }}"
+        COGNITO_IDENTITY_PROVIDER_NAME: "${{ inputs.cognito-identity-provider-name }}"
         ROLE_ARN: "${{ inputs.role-arn }}"
         CHAIN_ROLE_ARN: "${{ inputs.chain-role-arn }}"
         SET_IN_ENVIRONMENT: "${{ inputs.set-in-environment }}"
@@ -110,6 +111,11 @@ runs:
         
         if echo "$COGNITO_POOL_ID" | grep -Eqv "^[a-z]{2}-[a-z]{4,9}-[0-9]:[0-9a-f-]+$"; then
           echo "Value for Cognito Pool Id is invalid"
+          exit 1
+        fi
+
+        if echo "$COGNITO_IDENTITY_PROVIDER_NAME" | grep -Eqv "^token\.actions\.githubusercontent\.com(\/[a-zA-Z0-9-]+)?$"; then
+          echo "Value for Congito Identity Provider Name is invalid"
           exit 1
         fi
         

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,10 @@ inputs:
   auth-flow:
     required: true
     description: "Either basic or enhanced"
+  cognito-identity-provider-name:
+    required: false
+    default: "token.actions.githubusercontent.com"
+    description: "Name of the Congito Identity Provider Name. Can be used in case custom issuer is configured in GitHub Enterprise Cloud."
   audience:
     default: "cognito-identity.amazonaws.com"
     required: false
@@ -323,17 +327,18 @@ runs:
         AWS_ACCOUNT_ID: "${{ steps.aws_account_id.outputs.value }}"
         AWS_REGION: "${{ steps.aws_region.outputs.value }}"
         COGNITO_IDENTITY_POOL_ID: "${{ inputs.cognito-identity-pool-id }}"
+        COGNITO_IDENTITY_PROVIDER_NAME: "${{ inputs.cognito-identity-provider-name }}"
         DURATION_SECONDS: "${{ steps.duration_seconds.outputs.value }}"
         ROLE_ARN: "${{ inputs.role-arn }}"
         ROLE_SESSION_NAME: "${{ steps.role_session_name.outputs.value }}"
       run: |
         getIdResponse=$(aws cognito-identity get-id --identity-pool-id "$COGNITO_IDENTITY_POOL_ID" \
         --account-id "$AWS_ACCOUNT_ID" \
-        --logins '{"token.actions.githubusercontent.com":"'"$ACCESS_TOKEN"'"}')
+        --logins '{"'"$COGNITO_IDENTITY_PROVIDER_NAME"'":"'"$ACCESS_TOKEN"'"}')
         identityId=$(echo "$getIdResponse" | jq -rc '.IdentityId')
 
         cognitoIdentityTokenResponse=$(aws cognito-identity get-open-id-token --identity-id "$identityId" \
-        --logins '{"token.actions.githubusercontent.com":"'"$ACCESS_TOKEN"'"}')
+        --logins '{"'"$COGNITO_IDENTITY_PROVIDER_NAME"'":"'"$ACCESS_TOKEN"'"}')
         cognitoIdentityOidcAccessToken=$(echo "$cognitoIdentityTokenResponse" | jq -r '.Token')
         
         echo "::add-mask::$cognitoIdentityOidcAccessToken"
@@ -370,10 +375,14 @@ runs:
         AWS_ACCOUNT_ID: "${{ steps.aws_account_id.outputs.value }}"
         AWS_REGION: "${{ steps.aws_region.outputs.value }}"
         POOL_ID: "${{ inputs.cognito-identity-pool-id }}"
+        IDENTITY_PROVIDER_NAME: "${{ inputs.cognito-identity-provider-name }}"
         ROLE_ARN: "${{ inputs.role-arn }}"
         ACCESS_TOKEN: "${{ steps.token.outputs.token }}"
       run: |
-        response=$(aws cognito-identity get-id --identity-pool-id "$POOL_ID" --account-id "$AWS_ACCOUNT_ID" --logins '{"token.actions.githubusercontent.com":"'"$ACCESS_TOKEN"'"}')
+        response=$(aws cognito-identity get-id \
+        --identity-pool-id "$POOL_ID" \
+        --account-id "$AWS_ACCOUNT_ID" \
+        --logins '{"'"$IDENTITY_PROVIDER_NAME"'":"'"$ACCESS_TOKEN"'"}')
         identityId=$(echo $response | jq -rc '.IdentityId')
         
         customRoleArn=""
@@ -384,7 +393,7 @@ runs:
         
         awsCredentials=$(aws cognito-identity get-credentials-for-identity \
         --identity-id "$identityId" \
-        --logins '{"token.actions.githubusercontent.com":"'"$ACCESS_TOKEN"'"}' $customRoleArn)
+        --logins '{"'"$IDENTITY_PROVIDER_NAME"'":"'"$ACCESS_TOKEN"'"}' $customRoleArn)
         
         awsAccessKeyId=$(echo "$awsCredentials" | jq -r ".Credentials.AccessKeyId")
         awsSecretAccessKey=$(echo "$awsCredentials" | jq -r ".Credentials.SecretKey")


### PR DESCRIPTION
Added ability to customize Identity Provider Name via `cognito-identity-provider-name` input which is required in case `issuer` claim is customized in GitHub Enterprise Cloud: https://docs.github.com/en/enterprise-cloud@latest/actions/security-for-github-actions/security-hardening-your-deployments/about-security-hardening-with-openid-connect#customizing-the-issuer-value-for-an-enterprise

~I have not tested this~, but I suspect it is the reason why after customizing the claim I'm getting:
```sh
An error occurred (NotAuthorizedException) when calling the GetId operation: Invalid login token. Issuer doesn't match providerName
```

**Update:**
I have tested these changes by using my forked version in my project and can confirm they work.